### PR TITLE
added space before period in final line to fix assert error in Ardour3

### DIFF
--- a/CrossOver3/ttl/CrossOver3.ttl
+++ b/CrossOver3/ttl/CrossOver3.ttl
@@ -126,14 +126,15 @@ lv2:port
     lv2:minimum 0;
     lv2:maximum 2;
 ];
-    mod:gui [
-        a mod:Gui;
-        mod:resourcesDirectory <modgui>;
-        mod:iconTemplate <modgui/icon-crossover-3.html>;
-        mod:templateData <modgui/data-crossover-3.json>;
-        mod:screenshot <modgui/screenshot-crossover-3.png>;
-        mod:thumbnail <modgui/thumb-crossover-3.png>;
-    ];
 
-    lv2:minorVersion 1;
-    lv2:microVersion 0.
+mod:gui [
+    a mod:Gui;
+    mod:resourcesDirectory <modgui>;
+    mod:iconTemplate <modgui/icon-crossover-3.html>;
+    mod:templateData <modgui/data-crossover-3.json>;
+    mod:screenshot <modgui/screenshot-crossover-3.png>;
+    mod:thumbnail <modgui/thumb-crossover-3.png>;
+];
+
+lv2:minorVersion 1;
+lv2:microVersion 0 .


### PR DESCRIPTION
The final line would cause an assert error when importing the plugin into ardour3 on boot in the current testing version of KXstudio:

```
Scanning folders for bundled LV2s: /opt/ardour3/lib/LV2
error: /usr/lib/lv2/mod-crossover3.lv2/CrossOver3.ttl:139:23: expected `.', not `'
assertion failure: "! outputsReached" in file ../../libs/distrho/src/DistrhoPluginVST.cpp, line 1020
assertion failure: "! outputsReached" in file ../../libs/distrho/src/DistrhoPluginVST.cpp, line 1020
assertion failure: "! outputsReached" in file ../../libs/distrho/src/DistrhoPluginVST.cpp, line 1020
```

I found that adding a space in the final line between the '0' and '.' to change from "lv2:microVersion 0." into "lv2:microVersion 0 ." fixed this assert error.  I believe ardour wasn't interpreting the final '.' as the end of the turtle statement, possible because it was parsing the '0.' as a double instead of int or something else.

Also I don't know why mod:gui was indetened, but I think it would be more consistent use of whitespace to remove the indent and add a new line.
